### PR TITLE
table3 molecule scripts: assert all chemicals have target labels

### DIFF
--- a/table_generation/table3_cellvsnet_molecule_chemberta.py
+++ b/table_generation/table3_cellvsnet_molecule_chemberta.py
@@ -23,6 +23,7 @@ PATH_L1000 = DATA_DIR / 'trt_cp_smiles_qc.csv'
 PATH_CTLS = DATA_DIR / 'ctrls.csv'
 EMBEDDING_NPZ_FILE = DATA_DIR / 'gene_embeddings' / 'chemberta_embeddings.npz'
 PATH_SPLIT_MAP = DATA_DIR / 'gene_embeddings' / 'unseen_perturbation_splits' / 'trt_cp_split_map.csv'
+PATH_PERT_INFO = DATA_DIR / 'gene_embeddings' / 'perts_targets.csv'
 
 OUTPUT_DIR = Path('./chemberta_model_outputs')
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
@@ -79,6 +80,22 @@ df = df.merge(split_map_df[['inst_id', 'dataset_split']], on='inst_id', how='inn
 
 if len(df) < len(split_map_df):
     print(f"Warning: {len(split_map_df) - len(df)} samples from the split map were not found in the main data after QC/filters.")
+
+# Comparability guard: every chemical in the trt_cp evaluation set must have a
+# known target in perts_targets.csv. The target-side (gene) Table 3 columns
+# silently drop perts whose targets aren't in the gene embeddings; if a future
+# perts_targets.csv adds molecules without target labels, the molecule-side
+# scripts would still evaluate them and the Chemical column of Table 3 would
+# stop being row-comparable. Fail loudly instead.
+pert_info = pd.read_csv(PATH_PERT_INFO)
+perts_with_targets = set(pert_info.loc[pert_info['pert_iname'].notna(), 'pert_id'])
+missing = sorted(set(df['pert_id'].dropna().unique()) - perts_with_targets)
+assert not missing, (
+    f"{len(missing)} pert_ids in the trt_cp benchmark split have no target label in "
+    f"{PATH_PERT_INFO.name}; the gene-side Table 3 columns drop these via the embedding "
+    f"intersection, so evaluating ChemBERTa on them would break within-column "
+    f"comparability. First few missing: {missing[:5]}"
+)
 
 df_train = df[df['dataset_split'] == 'train'].copy()
 df_test = df[df['dataset_split'] == 'test'].copy()

--- a/table_generation/table3_cellvsnet_molecule_fingerprint.py
+++ b/table_generation/table3_cellvsnet_molecule_fingerprint.py
@@ -23,6 +23,7 @@ DATA_DIR = Path(os.environ["CONTEXTPERT_DATA_DIR"])
 PATH_L1000 = DATA_DIR / 'trt_cp_smiles_qc.csv'
 PATH_CTLS = DATA_DIR / 'ctrls.csv'
 PATH_SPLIT_MAP = DATA_DIR / 'gene_embeddings' / 'unseen_perturbation_splits' / 'trt_cp_split_map.csv'
+PATH_PERT_INFO = DATA_DIR / 'gene_embeddings' / 'perts_targets.csv'
 
 OUTPUT_DIR = Path('./morgan_model_outputs')
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
@@ -78,6 +79,22 @@ df = df.merge(split_map_df[['inst_id', 'dataset_split']], on='inst_id', how='inn
 
 if len(df) < len(split_map_df):
     print(f"Warning: {len(split_map_df) - len(df)} samples from the split map were not found in the main data after QC/filters.")
+
+# Comparability guard: every chemical in the trt_cp evaluation set must have a
+# known target in perts_targets.csv. The target-side (gene) Table 3 columns
+# silently drop perts whose targets aren't in the gene embeddings; if a future
+# perts_targets.csv adds molecules without target labels, the molecule-side
+# scripts would still evaluate them and the Chemical column of Table 3 would
+# stop being row-comparable. Fail loudly instead.
+pert_info = pd.read_csv(PATH_PERT_INFO)
+perts_with_targets = set(pert_info.loc[pert_info['pert_iname'].notna(), 'pert_id'])
+missing = sorted(set(df['pert_id'].dropna().unique()) - perts_with_targets)
+assert not missing, (
+    f"{len(missing)} pert_ids in the trt_cp benchmark split have no target label in "
+    f"{PATH_PERT_INFO.name}; the gene-side Table 3 columns drop these via the embedding "
+    f"intersection, so evaluating Morgan fingerprints on them would break within-column "
+    f"comparability. First few missing: {missing[:5]}"
+)
 
 df_train = df[df['dataset_split'] == 'train'].copy()
 df_test = df[df['dataset_split'] == 'test'].copy()


### PR DESCRIPTION
Adds a comparability guard in both molecule-side Table 3 scripts: after the trt_cp_split_map merge, every pert_id must appear in perts_targets.csv with a non-null pert_iname. The target-side gene script silently drops perts whose targets aren't in the embeddings via its intersection filter, so if a future update to perts_targets.csv adds molecules without target labels the molecule columns would still evaluate them and Table 3's Chemical column would stop being row-comparable. Fail loudly with a list of offending pert_ids instead.

Verified against current data: all 522 perts in trt_cp_split_map.csv have targets, so the assertion passes; the 12,461 untargeted trt_cp perts in the broader QC'd LINCS pool are correctly outside the benchmark split.